### PR TITLE
Add pytest tests and GitHub Actions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,23 @@
+name: Python Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,32 @@
+import sys, os; sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import importlib
+import os
+
+import pytest
+
+
+def reload_config(monkeypatch, **env_vars):
+    for key, value in env_vars.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    import config as cfg
+    return importlib.reload(cfg)
+
+
+def test_default_model(monkeypatch):
+    cfg = reload_config(monkeypatch, DEFAULT_MODEL=None)
+    assert cfg.Config.DEFAULT_MODEL == "gpt-3.5-turbo"
+
+
+def test_environment_override(monkeypatch):
+    cfg = reload_config(monkeypatch, DEFAULT_MODEL="custom-model")
+    assert cfg.Config.DEFAULT_MODEL == "custom-model"
+
+
+def test_testing_config(monkeypatch):
+    cfg = reload_config(monkeypatch)
+    test_cfg = cfg.TestingConfig()
+    assert test_cfg.TESTING is True
+    assert test_cfg.CHROMA_PERSIST_DIRECTORY == "./test_chroma_db"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest on pull requests
- create basic unit tests for configuration
- add `.gitignore` for caches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a63f3dcb88328b4bd784c79a4c738