### PR TITLE
Expand test coverage

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,62 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import types
+
+# Provide dummy external modules before importing app
+class DummyLimiter:
+    def __init__(self, app, key_func=None, default_limits=None):
+        self.app = app
+
+class DummyLLMService:
+    def __init__(self, api_key=None, model=None):
+        self.api_key = api_key
+        self.model = model
+    def generate(self, msg):
+        return f"reply:{msg}"
+
+class DummyVectorStoreService:
+    def __init__(self, persist_directory=None):
+        self.persist_directory = persist_directory
+
+# Stubs for heavy dependencies
+sys.modules.setdefault("nemollm", types.ModuleType("nemollm"))
+sys.modules["nemollm"].NemoLLM = object
+sys.modules.setdefault("chromadb", types.ModuleType("chromadb"))
+sys.modules["chromadb"].PersistentClient = object
+sys.modules.setdefault("chromadb.config", types.ModuleType("chromadb.config"))
+sys.modules["chromadb.config"].Settings = object
+
+import app as app_module
+
+
+def make_app(monkeypatch):
+    monkeypatch.setattr(app_module, "Limiter", DummyLimiter)
+    monkeypatch.setattr("services.llm_service.LLMService", DummyLLMService)
+    monkeypatch.setattr("services.vector_store.VectorStoreService", DummyVectorStoreService)
+    monkeypatch.setattr(app_module, "LLMService", DummyLLMService)
+    monkeypatch.setattr(app_module, "VectorStoreService", DummyVectorStoreService)
+    return app_module.create_app()
+
+
+def test_create_app(monkeypatch):
+    flask_app = make_app(monkeypatch)
+    assert isinstance(flask_app.llm_service, DummyLLMService)
+    assert isinstance(flask_app.vector_store, DummyVectorStoreService)
+    assert isinstance(flask_app.limiter, DummyLimiter)
+
+
+def test_chat_route(monkeypatch):
+    flask_app = make_app(monkeypatch)
+    flask_app.config["API_KEY"] = "token"
+    client = flask_app.test_client()
+
+    resp = client.post("/api/chat", json={"message": "hi"}, headers={"X-API-Key": "token"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"response": "reply:hi"}
+
+    resp = client.post("/api/chat", json={}, headers={"X-API-Key": "token"})
+    assert resp.status_code == 400
+
+    resp = client.post("/api/chat", json={"message": "hi"})
+    assert resp.status_code == 401

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,33 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from flask import Flask
+from utils.auth import require_api_key
+
+
+def create_app(api_key="secret"):
+    app = Flask(__name__)
+    app.config["API_KEY"] = api_key
+
+    @app.route("/protected")
+    @require_api_key
+    def protected():
+        return "ok"
+
+    return app
+
+
+def test_require_api_key_success():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/protected", headers={"X-API-Key": "secret"})
+    assert resp.status_code == 200
+    assert resp.data == b"ok"
+
+
+def test_require_api_key_failure():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/protected")
+    assert resp.status_code == 401
+    assert resp.get_json()["error"] == "Unauthorized"

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,0 +1,40 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import types
+import importlib
+
+# Provide dummy nemollm module so import works
+dummy_module = types.ModuleType("nemollm")
+dummy_module.NemoLLM = object
+sys.modules.setdefault("nemollm", dummy_module)
+
+import services.llm_service as llm_service
+
+
+class DummyNemoLLM:
+    def __init__(self, api_key):
+        self.api_key = api_key
+
+    def generate_chat(self, model, chat_context):
+        return {"choices": [{"message": {"content": f"{model}:{chat_context[0]['content']}"}}]}
+
+
+class DummyBadNemoLLM:
+    def __init__(self, api_key):
+        self.api_key = api_key
+
+    def generate_chat(self, model, chat_context):
+        return {"unexpected": True}
+
+
+def test_generate_success(monkeypatch):
+    monkeypatch.setattr(llm_service, "NemoLLM", DummyNemoLLM)
+    service = llm_service.LLMService("k", "m")
+    assert service.generate("hi") == "m:hi"
+
+
+def test_generate_fallback(monkeypatch):
+    monkeypatch.setattr(llm_service, "NemoLLM", DummyBadNemoLLM)
+    service = llm_service.LLMService("k", "m")
+    assert service.generate("hi") == str({"unexpected": True})

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,46 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import types
+
+# Provide dummy chromadb module before import
+class DummyCollection:
+    def __init__(self):
+        self.add_calls = []
+        self.queries = []
+    def add(self, embeddings, metadatas, ids):
+        self.add_calls.append((embeddings, metadatas, ids))
+    def query(self, query_embeddings, n_results):
+        self.queries.append((query_embeddings, n_results))
+        return {"results": n_results}
+
+class DummyClient:
+    def __init__(self, path):
+        self.path = path
+        self.collection = DummyCollection()
+    def get_or_create_collection(self, name):
+        return self.collection
+
+dummy_chromadb = types.SimpleNamespace(PersistentClient=DummyClient)
+sys.modules.setdefault("chromadb", dummy_chromadb)
+sys.modules.setdefault("chromadb.config", types.ModuleType("chromadb.config"))
+sys.modules["chromadb.config"].Settings = object
+
+import services.vector_store as vector_store
+
+
+def test_vector_store_add_and_query(monkeypatch, tmp_path):
+    # Replace chromadb with dummy implementation
+    monkeypatch.setattr(vector_store, "chromadb", dummy_chromadb)
+
+    service = vector_store.VectorStoreService(persist_directory=str(tmp_path))
+    assert service.persist_directory == str(tmp_path)
+
+    embeddings = [[0.1, 0.2]]
+    metas = [{"id": 1}]
+    service.add(embeddings, metas)
+    assert service.collection.add_calls[0][0] == embeddings
+
+    result = service.query([0.3, 0.4], n_results=3)
+    assert result == {"results": 3}
+    assert service.collection.queries[0] == ([[0.3, 0.4]], 3)


### PR DESCRIPTION
## Summary
- add test for API key auth
- add tests for NeMo-based LLM service
- add tests for VectorStoreService
- add tests for app factory and chat route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6f255890832889ebb58acc1db7df