### PR TITLE
Add ICS 205 endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Content-Type: application/json
 }
 ```
 
+#### Generate ICS 205 Plan
+```bash
+POST /api/ics205
+Content-Type: application/json
+
+{
+  "incident": "Fire at Main St"
+}
+```
+
 ### Health Check
 ```bash
 GET /api/health
@@ -147,6 +157,7 @@ curl http://localhost:5000/api/health
 ├── routes/               # API route blueprints
 │   ├── documents.py      # Document management
 │   ├── chat.py          # Chat endpoints
+│   ├── ics205.py        # ICS 205 form generation
 │   └── health.py        # Health checks
 ├── services/            # Business logic services
 │   ├── vector_store.py  # Chroma vector database

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,5 +1,7 @@
 from .chat import chat_bp
+from .ics205 import ics_bp
 
 
 def register_routes(app):
     app.register_blueprint(chat_bp)
+    app.register_blueprint(ics_bp)

--- a/routes/ics205.py
+++ b/routes/ics205.py
@@ -1,0 +1,20 @@
+from flask import Blueprint, request, jsonify, current_app
+from utils.auth import require_api_key
+
+ics_bp = Blueprint("ics205", __name__)
+
+
+@ics_bp.route("/api/ics205", methods=["POST"])
+@require_api_key
+def generate_ics205():
+    data = request.get_json() or {}
+    incident = data.get("incident")
+    if not incident:
+        return jsonify({"error": "incident required"}), 400
+    llm_service = current_app.llm_service
+    prompt = (
+        f"Prepare an ICS 205 Incident Radio Communications Plan for this incident: {incident}. "
+        "Return the plan as a Markdown table."
+    )
+    response = llm_service.generate(prompt)
+    return jsonify({"ics205": response})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -60,3 +60,21 @@ def test_chat_route(monkeypatch):
 
     resp = client.post("/api/chat", json={"message": "hi"})
     assert resp.status_code == 401
+
+
+def test_ics205_route(monkeypatch):
+    flask_app = make_app(monkeypatch)
+    flask_app.config["API_KEY"] = "token"
+    client = flask_app.test_client()
+
+    incident = "Test"
+    prompt = (
+        f"Prepare an ICS 205 Incident Radio Communications Plan for this incident: {incident}. "
+        "Return the plan as a Markdown table."
+    )
+    resp = client.post("/api/ics205", json={"incident": incident}, headers={"X-API-Key": "token"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ics205": f"reply:{prompt}"}
+
+    resp = client.post("/api/ics205", json={}, headers={"X-API-Key": "token"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- implement `/api/ics205` endpoint to generate an ICS 205 radio communications plan
- register the new blueprint
- document the endpoint and update architecture diagram
- test the new route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a726f8bdc83288e85728b203e0d49